### PR TITLE
fix: attribute completions for a multi-line opening tag FUI-1302

### DIFF
--- a/src/plugin/completions/helpers.test.ts
+++ b/src/plugin/completions/helpers.test.ts
@@ -113,13 +113,23 @@ describe('getCompletionType', () => {
       { key: 'custom-element-attribute', params: 'cus-elem' },
     ],
     [
-      'Key "custom-element-attribute" and gets custom element when curso is inside of a fully closed element',
+      'Key "custom-element-attribute" and gets custom element when cursor is inside of a fully closed element',
       [
         html`
           <ce-elem></ce-elem>
           <cus-elem attr="value"></cus-elem>
         `,
         { line: 2, character: 32 },
+      ],
+      { key: 'custom-element-attribute', params: 'cus-elem' },
+    ],
+    [
+      'Key "custom-element-attribute" and gets custom element when cursor is on the next line to an opening tag',
+      [
+        html`
+          <cus-elem
+          `,
+        { line: 2, character: 2 },
       ],
       { key: 'custom-element-attribute', params: 'cus-elem' },
     ],

--- a/src/plugin/completions/helpers.ts
+++ b/src/plugin/completions/helpers.ts
@@ -17,26 +17,26 @@ export const suggestTags = (line: string) => unfinishedTag.test(line);
 export const suggestCustomElements = (line: string) => {
   if (!unfinishedCustomElement.test(line)) return false;
   const lastTag = line.split(/</).pop() as string;
-  return lastTag.split(' ')[0];
+  return lastTag.split(' ')[0].trim();
 };
 
 const unfinishedTag = /<[^>]*$/;
 
 // Like an unfinished tag, but with a hyphen
-const unfinishedCustomElement = /<.+-[^>]*$/;
+const unfinishedCustomElement = /<.+-[^>]*$/m;
 
 export function getCompletionType(
   context: TemplateContext,
   position: LineAndCharacter
 ): CompletionTypeParams {
   const rawLine = context.rawText.split(/\n/g)[position.line];
-  const processedLine = replaceTemplateStringBinding(rawLine);
+  const processedLine = replaceTemplateStringBinding(
+    context.rawText.substring(0, context.toOffset(position))
+  );
 
   {
     let tagname: string | false;
-    if (
-      ((tagname = suggestCustomElements(processedLine.substring(0, position.character))), tagname)
-    ) {
+    if (((tagname = suggestCustomElements(processedLine)), tagname)) {
       return {
         key: 'custom-element-attribute',
         params: tagname,

--- a/src/plugin/utils/strings.ts
+++ b/src/plugin/utils/strings.ts
@@ -13,8 +13,8 @@ import { TemplateContext } from 'typescript-template-language-service-decorator'
  * ````
  */
 export function replaceTemplateStringBinding(line: string): string {
-  return line.replace(/="\${(.+?)}"/g, (...args) => {
-    return '="${' + 'y'.repeat(args[1].length) + '}"';
+  return line.replace(/\${(.+?)}/g, (...args) => {
+    return '${' + 'y'.repeat(args[1].length) + '}';
   });
 }
 


### PR DESCRIPTION
Fixes a bug where the LSP wouldn't understand the completion type if your cursor was on the next line to the opening of the tag name decleration.

Example
```
<datasource-element
   src="localhost:8000"
   secure
>
```
If you create a new line after the secure boolean attribute and initiate completion, you should have recieved all of the appropriate completions for the `datasource-element` custom element, but you were not.

Before:
https://github.com/genesiscommunitysuccess/custom-elements-lsp/assets/43502076/ee47ef96-87bd-45c6-a518-49e65c01b75c

After:
https://github.com/genesiscommunitysuccess/custom-elements-lsp/assets/43502076/4fdd2b84-d805-437b-9262-b379dfe99158

