### PR TITLE
fix: regression with lost superclass into from library FUI-1388

### DIFF
--- a/src/plugin/custom-elements/manifest/repository.ts
+++ b/src/plugin/custom-elements/manifest/repository.ts
@@ -98,6 +98,9 @@ export class LiveUpdatingCEManifestRepository implements ManifestRepository {
     if (this.fastEnabled) {
       analyzerArgs.push('--fast');
     }
+    if (this.config.dependencies.length > 0) {
+      analyzerArgs.push('--dependencies');
+    }
     const manifest = await this.analyzer({
       argv: analyzerArgs,
       cwd: this.io.getNormalisedRootPath(),


### PR DESCRIPTION
Fixes a small regression from #26 which missed applying the dependency flag to the analyzer when required. This was meaning that custom elements which extend a superclass from a library with a dependency was not correctly finding it.

Before: 
![Screenshot 2023-07-12 at 15 23 45](https://github.com/genesiscommunitysuccess/custom-elements-lsp/assets/43502076/e68f7c68-7ac6-461e-813b-ddb4187c98ca)


After:
![Screenshot 2023-07-12 at 15 23 28](https://github.com/genesiscommunitysuccess/custom-elements-lsp/assets/43502076/aec8d4d4-a5ef-447f-97f4-3177d9bff0b9)
