### PR TITLE
feat: use the parser config from tsconfig when running analyzer script FUI-1444

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ You can generate a copy of the manifest file that the plugin is using by running
 }
 ```
 
-The script currently takes two optional arguments:
+The script currently takes an optional argument:
 - `--tsconfig` - the path to the tsconfig.json file to use. Defaults to `process.cwd()`.
-- `--fastEnabled` - whether to use the ms fast parsing mode of the manifest repository. Defaults to `false`.
+- `--fastEnable` is set from the plugin config.
 
 This `package.json` needs to be the same location on the file system that the `srcRouteFromTSServer` relative path gets you to, as explained in [the setup section](#plugin-setup-and-usage).
 

--- a/README.md
+++ b/README.md
@@ -96,16 +96,18 @@ You can generate a copy of the manifest file that the plugin is using by running
 ```json
 {
   "scripts": {
-    "lsp:analyze": "custom-elements-analyze --src='src/**/*.{js,ts}' --dependencies='[\"node_modules/example-lib/**/custom-elements.json\",\"!**/@custom-elements-manifest/**/*\"]'",
+    "lsp:analyze": "custom-elements-analyze --tsconfig='./src/tsconfig.json'",
   },
 }
 ```
 
-This example has the `--src` and `--dependencies` parameters matching the configuration in `./example/src/tsconfig.json`. This `package.json` needs to be the same location on the filesystem that the `srcRouteFromTSServer` relative path gets you to, as explained in [the setup section](#plugin-setup-and-usage).
+The script currently takes two optional arguments:
+- `--tsconfig` - the path to the tsconfig.json file to use. Defaults to `process.cwd()`.
+- `--fastEnabled` - whether to use the ms fast parsing mode of the manifest repository. Defaults to `false`.
 
-> Take care with the syntax for specifying an array of globs for the dependencies. You are required to quote the array and also quote the individual items as strings. Refer back to the example given to double check.
+This `package.json` needs to be the same location on the file system that the `srcRouteFromTSServer` relative path gets you to, as explained in [the setup section](#plugin-setup-and-usage).
 
-2. Run the npm script `npm run lsp:analyze`.
+2. Run the npm script you just created with `npm run lsp:analyze`.
 3. Check `ce.json` to see what components have issues, or are missing from the manifest.
 4. If there are any issues then you can change the glob patterns and repeat from step 1 until you're happy.
 5. Once you are receiving the correct output from the script you can update your `tsconfig.json` to fix the issue in the LSP plugin.

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -20,13 +20,14 @@
     },
     "..": {
       "name": "@genesiscommunitysuccess/custom-elements-lsp",
-      "version": "0.0.5",
+      "version": "1.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@custom-elements-manifest/analyzer": "^0.8.0",
         "chokidar": "^3.5.3",
         "debounce": "^1.2.1",
+        "get-tsconfig": "^4.7.0",
         "globby": "^13.1.4",
         "minimist-lite": "^2.2.1",
         "node-html-parser": "^6.1.5",

--- a/example/package.json
+++ b/example/package.json
@@ -5,7 +5,7 @@
     "bootstrap:module:ci": "npm ci && npm run build && npm run lsp:analyze",
     "build": "tsc && vite build",
     "dev": "npm run build && npm run start",
-    "lsp:analyze": "custom-elements-analyze --src='src/**/*.{js,ts}' --dependencies='[\"node_modules/example-lib/**/custom-elements.json\",\"!**/@custom-elements-manifest/**/*\"]'",
+    "lsp:analyze": "custom-elements-analyze --tsconfig='./src/tsconfig.json'",
     "preview": "vite preview",
     "start": "vite"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@custom-elements-manifest/analyzer": "^0.8.0",
         "chokidar": "^3.5.3",
         "debounce": "^1.2.1",
+        "get-tsconfig": "^4.7.0",
         "globby": "^13.1.4",
         "minimist-lite": "^2.2.1",
         "node-html-parser": "^6.1.5",
@@ -6532,10 +6533,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.6.0.tgz",
-      "integrity": "sha512-lgbo68hHTQnFddybKbbs/RDRJnJT5YyGy2kQzVwbq+g67X73i+5MVTval34QxGkOe9X5Ujf1UYpCaphLyltjEg==",
-      "dev": true,
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.0.tgz",
+      "integrity": "sha512-pmjiZ7xtB8URYm74PlGJozDNyhvsVLUcpBa8DZBG3bWHwaHa9bPiRpiSfovw+fjhwONSCWKRyk+JQHEGZmMrzw==",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
       },
@@ -14268,7 +14268,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
@@ -20863,10 +20862,9 @@
       }
     },
     "get-tsconfig": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.6.0.tgz",
-      "integrity": "sha512-lgbo68hHTQnFddybKbbs/RDRJnJT5YyGy2kQzVwbq+g67X73i+5MVTval34QxGkOe9X5Ujf1UYpCaphLyltjEg==",
-      "dev": true,
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.0.tgz",
+      "integrity": "sha512-pmjiZ7xtB8URYm74PlGJozDNyhvsVLUcpBa8DZBG3bWHwaHa9bPiRpiSfovw+fjhwONSCWKRyk+JQHEGZmMrzw==",
       "requires": {
         "resolve-pkg-maps": "^1.0.0"
       }
@@ -26280,8 +26278,7 @@
     "resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="
     },
     "resolve.exports": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@custom-elements-manifest/analyzer": "^0.8.0",
     "chokidar": "^3.5.3",
     "debounce": "^1.2.1",
+    "get-tsconfig": "^4.7.0",
     "globby": "^13.1.4",
     "minimist-lite": "^2.2.1",
     "node-html-parser": "^6.1.5",

--- a/scripts/parser/analyze.js
+++ b/scripts/parser/analyze.js
@@ -6,9 +6,9 @@
  * seeing, which is useful if you're not receiving the results
  * in the LSP that you expect.
  *
- * The script currently takes two optional arguments:
+ * The script currently takes an optional argument:
  * - `--tsconfig` - the path to the tsconfig.json file to use. Defaults to `process.cwd()`.
- * - `--fastEnabled` - whether to use the ms fast parsing mode of the manifest repository. Defaults to `false`.
+ * - `--fastEnable` is set from the plugin config.
  */
 
 import { readFileSync, writeFileSync } from 'fs';
@@ -41,15 +41,15 @@ if (tsConfig === null) {
 
 const lspPluginConfigOptions = tsConfig?.config?.compilerOptions?.plugins?.find(
   (plugin) => plugin.name === '@genesiscommunitysuccess/custom-elements-lsp'
-)?.parser;
+);
 
-if (!lspPluginConfigOptions) {
+if (!lspPluginConfigOptions?.parser) {
   console.error(`Cannot get parser config from tsconfig found at: "${tsconfigPath}"`);
   process.exit(2);
 }
 
 const config = mixinParserConfigDefaults({
-  ...lspPluginConfigOptions,
+  ...lspPluginConfigOptions.parser,
 });
 
 const logger = {
@@ -63,7 +63,12 @@ const io = {
   getNormalisedRootPath: () => process.cwd() + '/',
 };
 
-const manifestRepo = new LiveUpdatingCEManifestRepository(logger, io, config, !!args.fastEnabled);
+const manifestRepo = new LiveUpdatingCEManifestRepository(
+  logger,
+  io,
+  config,
+  !!lspPluginConfigOptions?.fastEnable
+);
 await manifestRepo.analyzeAndUpdate();
 
 writeFileSync(OUT_FILE, JSON.stringify(manifestRepo.manifest, null, 2));

--- a/scripts/parser/analyze.js
+++ b/scripts/parser/analyze.js
@@ -5,6 +5,10 @@
  * out the glob paths and check the output that the LSP would be
  * seeing, which is useful if you're not receiving the results
  * in the LSP that you expect.
+ *
+ * The script currently takes two optional arguments:
+ * - `--tsconfig` - the path to the tsconfig.json file to use. Defaults to `process.cwd()`.
+ * - `--fastEnabled` - whether to use the ms fast parsing mode of the manifest repository. Defaults to `false`.
  */
 
 import { readFileSync, writeFileSync } from 'fs';

--- a/scripts/parser/analyze.js
+++ b/scripts/parser/analyze.js
@@ -38,7 +38,6 @@ if (tsConfig === null) {
   console.error(`Could not find tsconfig at: "${tsconfigPath}"`);
   process.exit(1);
 }
-console.log(`tsConfig: ${JSON.stringify(tsConfig)}`);
 
 const lspPluginConfigOptions = tsConfig?.config?.compilerOptions?.plugins?.find(
   (plugin) => plugin.name === '@genesiscommunitysuccess/custom-elements-lsp'


### PR DESCRIPTION
⚠️ BREAKING CHANGE: This alters the API that you call the analyzer binary which is bundled with the LSP ⚠️

🤔  &nbsp; **What does this PR do?**

Since #35 the static analyzer script has been repurposed to call the analyzer functionality from the plugin, allowing it to debug for the user what the analyzer can see.
- Previously it was taking input for `src` and `dependencies` through its own CLI interface.
- This was a point of weakness with the debugging beacuse the user could mess up the configuration passed into the analyzer script, giving different results. This was especially confusing because of how careful you needed to be with escaping quotes in the `package.json` command.
- This PR updates the api so you can pass in the path to the tsconfig.json, and the script will just read the input from there.
- Also grabs `fastEnable` config from the `tsconfig.json` .
- Above fixes issue that `fastEnable` should have been enabled in master for `example` app.
- Updated readme to account for this change.

📑  &nbsp; **How should this be tested?**

Update test steps to match your PR:

```
1. `git fetch`
2. `npm run bootstrap`
3. `cd example`
4. Disable `fastEnable` setting in the `example/src/tsconfig.json`
```
Then run:
```
git checkout master && \
npm run lsp:analyze && \
cp ce.json /tmp/master_ce.json && \
git checkout matteematt/FUI-1444-align-analyzer-config && \
npm run lsp:analyze && \
cp ce.json /tmp/branch_ce.json && \
wc /tmp/master_ce.json /tmp/branch_ce.json
```
You should see that the word and line count is identical between the files before and after this change, showing that `ce.json` generated is functionally the same between this file and master. The files will not be exactly the same as the order that the json file is filled out from the `@custom-elements-manifest/analyzer` script is non-deterministic. You disabled the `fastEnable` setting in step 4 as it was disabled in master accidentally.

You can then enable `fastEnable` in your tsconfig.json and see that the line count increases.

> These testing instructions assume that you've already setup the LSP in your IDE with the `example` app. If you haven't then follow the instructions in the `README.md`.

✅  &nbsp; **Checklist**

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes. - N/A
- [X] I have updated the project documentation.

<!-- TODO: Add links to contributing guidelines when completed -->

