### PR TITLE
fix: account for hoisted typescript binary when running analyzer script FUI-1411

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Parser options. These control the analysis of the source code to understand sema
 
 Only the `src` files are watched for changes to update the analyzer, if you update the dependencies containing manifest files you must restart the LSP for it to be aware of the changes.
 
+*WARNING:* If you are using a monorepo pattern with workspaces, you must account for potential hoisting of the TypeScript library in the `node_modules` to a parent directory. The path of `src` and `dependencies` will be relative to the path created from the typescript install location and the `srcRouteFromTSServer` config option.
+
 ### FAST Syntax
 
 Enable enhanced completions and diagnostics by setting the `"fastEnable": true` option in your `tsconfig.json`. This will enable syntax such as `@event` on the template definitions.
@@ -111,6 +113,14 @@ This `package.json` needs to be the same location on the file system that the `s
 3. Check `ce.json` to see what components have issues, or are missing from the manifest.
 4. If there are any issues then you can change the glob patterns and repeat from step 1 until you're happy.
 5. Once you are receiving the correct output from the script you can update your `tsconfig.json` to fix the issue in the LSP plugin.
+
+##### Analyzer Script Extra
+
+If you are still running into issues then you can spend time verifying that the debugging analyzer script is getting the same view as the CEP itself.
+1. Complete the `Setup Logging` section from the [contributing](./CONTRIBUTING.md) document.
+2. Run the CEP in your IDE and check the logs for a line that looks roughly like `Info 32   [14:43:25.686] [CE] Analyzing and updating manifest. Config: ...`
+3. Run the analyzer script and see the same line like `[log] Analyzing and updating manifest. Config: ...`
+4. Verify they're the same. If not then there is potentially something wrong with your plugin setup.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Base options.
 | Option                | Optional and Default | Explanation                                                                                                                                                                                                                                                                  |
 |---|---|--|
 | `name`                | False                | Need to set as `@genesiscommunitysuccess/custom-elements-lsp` to enable this plugin.                                                                                                                                                                                         |
-| `srcRootFromTSServer` | True (`"../../../"`)   | `srcRouteFromTSServer` is the relative path from the `tsserver.js` executable in your node modules, to your directory with the `package.json` where the project web root is located. This is likely to be `node_modules/typescript/lib/tsserver.js` hence we use `../../..`. |
+| `srcRootFromTSServer` | True (`"../../../"`)   | `srcRouteFromTSServer` is the relative path from the `tsserver.js` executable in your node modules, to your directory with the `package.json` where the project web root is located. This is likely to be `node_modules/typescript/lib/tsserver.js` hence we use `../../..`. *WARNING:* If you are using a monorepo pattern with workspaces, you must account for potential hoisting of the TypeScript library in the `node_modules` to a parent directory.|
 | `designSystemPrefix`  | True (N/A)           | Used to work with `%%prefix%%` to handle components registered as part of a design system. See [here](#advanced-usage).                                                                                                                                                      |
 | `fastEnable`          | True (disabled)      | Enables Microsoft FAST parsing and completion (e.g. `:prop` property binding syntax).                                                                                                                                                                                        |
 
@@ -69,7 +69,7 @@ Enable enhanced completions and diagnostics by setting the `"fastEnable": true` 
 
 You just need to setup VSCode to use your local typescript install as by default it will try and use a version of typescript it is bundled with.
 
-1. You need to create a `settings.json` file inside of a `.vscode` directory. We need to configure VSCode to see the locally installed typescript binary (ensure `typescript.tdsk` points to the `lib` directory of the project typescript install). You can see an example of this in this repository - `./example/.vscode/settings.json`.
+1. You need to create a `settings.json` file inside of a `.vscode` directory. We need to configure VSCode to see the locally installed typescript binary (ensure `typescript.tdsk` points to the `lib` directory of the project typescript install). You can see an example of this in this repository - `./example/.vscode/settings.json`. If npm has hoisted your typescript install, ensure the path you configure accounts for that.
 2. Launch VSCode on the project directory that contains the `.vscode` directory.
 3. Configure workspace version to local using `Typescript: Select Typescript Version` from the command palette https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript. If you are having issues seeing this menu option ensure you have a typescript file open.
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Enable enhanced completions and diagnostics by setting the `"fastEnable": true` 
 
 You just need to setup VSCode to use your local typescript install as by default it will try and use a version of typescript it is bundled with.
 
-1. You need to create a `settings.json` file inside of a `.vscode` directory. We need to configure VSCode to see the locally installed typescript binary (ensure `typescript.tdsk` points to the `lib` directory of the project typescript install). You can see an example of this in this repository - `./example/.vscode/settings.json`. If npm has hoisted your typescript install, ensure the path you configure accounts for that.
+1. You need to create a `settings.json` file inside of a `.vscode` directory, this is to configure VSCode to see the locally installed typescript binary (ensure `typescript.tdsk` points to the `lib` directory of the project typescript install). You can see an example of this in this repository - `./example/.vscode/settings.json`. If npm has hoisted your typescript install, ensure the path you configure accounts for that.
 2. Launch VSCode on the project directory that contains the `.vscode` directory.
 3. Configure workspace version to local using `Typescript: Select Typescript Version` from the command palette https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript. If you are having issues seeing this menu option ensure you have a typescript file open.
 

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -20,7 +20,7 @@
     },
     "..": {
       "name": "@genesiscommunitysuccess/custom-elements-lsp",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -31,6 +31,7 @@
         "globby": "^13.1.4",
         "minimist-lite": "^2.2.1",
         "node-html-parser": "^6.1.5",
+        "resolve": "^1.22.4",
         "resolve-pkg": "^2.0.0",
         "typescript-template-language-service-decorator": "^2.3.2"
       },
@@ -46,6 +47,7 @@
         "@semantic-release/release-notes-generator": "^11.0.4",
         "@types/debounce": "^1.2.1",
         "@types/jest": "^29.5.1",
+        "@types/resolve": "^1.20.2",
         "@typescript-eslint/eslint-plugin": "^5.2.0",
         "@typescript-eslint/parser": "^5.2.0",
         "conventional-changelog-conventionalcommits": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "globby": "^13.1.4",
         "minimist-lite": "^2.2.1",
         "node-html-parser": "^6.1.5",
+        "resolve": "^1.22.4",
         "resolve-pkg": "^2.0.0",
         "typescript-template-language-service-decorator": "^2.3.2"
       },
@@ -31,6 +32,7 @@
         "@semantic-release/release-notes-generator": "^11.0.4",
         "@types/debounce": "^1.2.1",
         "@types/jest": "^29.5.1",
+        "@types/resolve": "^1.20.2",
         "@typescript-eslint/eslint-plugin": "^5.2.0",
         "@typescript-eslint/parser": "^5.2.0",
         "conventional-changelog-conventionalcommits": "^5.0.0",
@@ -3295,6 +3297,12 @@
       "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
       "dev": true
     },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true
+    },
     "node_modules/@types/semver": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
@@ -6426,8 +6434,7 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.5",
@@ -6768,7 +6775,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -7139,10 +7145,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
-      "dev": true,
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -13690,8 +13695,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -14205,12 +14209,11 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
-      "dev": true,
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
       "dependencies": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -15338,7 +15341,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -18548,6 +18550,12 @@
       "integrity": "sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==",
       "dev": true
     },
+    "@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true
+    },
     "@types/semver": {
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.0.tgz",
@@ -20788,8 +20796,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "function.prototype.name": {
       "version": "1.1.5",
@@ -21049,7 +21056,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -21299,10 +21305,9 @@
       "dev": true
     },
     "is-core-module": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.0.tgz",
-      "integrity": "sha512-RECHCBCd/viahWmwj6enj19sKbHfJrddi/6cBDsNTKbNq0f7VeaUkBo60BqzvPqo/W54ChS62Z5qyun7cfOMqQ==",
-      "dev": true,
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
+      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -25869,8 +25874,7 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-type": {
       "version": "4.0.0",
@@ -26234,12 +26238,11 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
-      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
-      "dev": true,
+      "version": "1.22.4",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.4.tgz",
+      "integrity": "sha512-PXNdCiPqDqeUou+w1C2eTQbNfxKSuMxqTCuvlmmMsk1NWHL5fRrhY6Pl0qEYYc6+QqGClco1Qj8XnjPego4wfg==",
       "requires": {
-        "is-core-module": "^2.11.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -27028,8 +27031,7 @@
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
     },
     "synckit": {
       "version": "0.8.5",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "globby": "^13.1.4",
     "minimist-lite": "^2.2.1",
     "node-html-parser": "^6.1.5",
+    "resolve": "^1.22.4",
     "resolve-pkg": "^2.0.0",
     "typescript-template-language-service-decorator": "^2.3.2"
   },
@@ -86,6 +87,7 @@
     "@semantic-release/release-notes-generator": "^11.0.4",
     "@types/debounce": "^1.2.1",
     "@types/jest": "^29.5.1",
+    "@types/resolve": "^1.20.2",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "@typescript-eslint/parser": "^5.2.0",
     "conventional-changelog-conventionalcommits": "^5.0.0",

--- a/scripts/parser/analyze.js
+++ b/scripts/parser/analyze.js
@@ -21,6 +21,12 @@ import {
   mixinParserConfigDefaults,
 } from '../../out/plugin/custom-elements/manifest/repository.js';
 
+const EXIT_CODES = {
+  cant_resolve_typescript: 1,
+  cant_find_tsconfig: 2,
+  cant_get_parser_config: 3,
+};
+
 const OUT_FILE = 'ce.json';
 
 let typescriptResolution;
@@ -28,7 +34,7 @@ try {
   typescriptResolution = resolve('typescript');
 } catch (e) {
   console.error(`Could not resolve typescript: ${e.message}`);
-  process.exit(1);
+  process.exit(EXIT_CODES.cant_resolve_typescript);
 }
 
 const args = minimist(process.argv.slice(2));
@@ -46,7 +52,7 @@ const tsconfigPath =
 const tsConfig = getTsconfig(tsconfigPath);
 if (tsConfig === null) {
   console.error(`Could not find tsconfig at: "${tsconfigPath}"`);
-  process.exit(2);
+  process.exit(EXIT_CODES.cant_find_tsconfig);
 }
 
 const lspPluginConfigOptions = tsConfig?.config?.compilerOptions?.plugins?.find(
@@ -55,7 +61,7 @@ const lspPluginConfigOptions = tsConfig?.config?.compilerOptions?.plugins?.find(
 
 if (!lspPluginConfigOptions?.parser) {
   console.error(`Cannot get parser config from tsconfig found at: "${tsconfigPath}"`);
-  process.exit(3);
+  process.exit(EXIT_CODES.cant_get_parser_config);
 }
 
 const config = mixinParserConfigDefaults({

--- a/scripts/parser/analyze.js
+++ b/scripts/parser/analyze.js
@@ -12,10 +12,10 @@
  */
 
 import { readFileSync, writeFileSync } from 'fs';
+import nodepath from 'path';
 import { getTsconfig } from 'get-tsconfig';
 import minimist from 'minimist-lite';
 import resolve from 'resolve/sync.js';
-import nodepath from 'path';
 import {
   LiveUpdatingCEManifestRepository,
   mixinParserConfigDefaults,


### PR DESCRIPTION
🤔  &nbsp; **What does this PR do?**

- If you are using a monorepo pattern then the typescript install might be in a different location to the module root, due to hoisting.
- That is accounted for when running the plugin (as long as the user configures everything correctly).
- But the analyzer script does not account for that, and therefore was giving different results.
- This PR aligns the script, and updates the associated readme.

📑  &nbsp; **How should this be tested?**

Update test steps to match your PR:

This cannot be tested locally in the repo, you'll need an additional project which is setup to have the typescript install hoisted.

```
1. Checkout branch
2. `npm run bootstrap`
3. `npm link`
4. Open a typescript project which has a hoisted typescript install.
5. `npm link @genesiscommunitysuccess/custom-elements-lsp`
6. When running the script, verify that the output of the analyzer config (as explained in the readme changes) is the same as when you run the plugin itself
```

> These testing instructions assume that you've already setup the LSP in your IDE with the `example` app. If you haven't then follow the instructions in the `README.md`.

✅  &nbsp; **Checklist**

<!--- Review the list and put an x in the boxes that apply. -->

- [X] I have added tests for my changes.
- [X] I have updated the project documentation.
- [X] I have followed the [contribution guidelines](https://github.com/genesiscommunitysuccess/custom-elements-lsp/blob/master/CONTRIBUTING.md).
