### PR TITLE
feat: allow usage with tsconfig target es2015 or later FUI-1576

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     '**/out/**/*',
     '**/node_modules/**/*',
     'scripts/**/*',
+		'**/polyfill.ts'
   ],
   settings: {
     'import/resolver': {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,7 @@ module.exports = {
     '**/out/**/*',
     '**/node_modules/**/*',
     'scripts/**/*',
-		'**/polyfill.ts'
+    '**/polyfill.ts',
   ],
   settings: {
     'import/resolver': {

--- a/packages/core/analyzer-import-alias-plugin/src/dev.ts
+++ b/packages/core/analyzer-import-alias-plugin/src/dev.ts
@@ -11,8 +11,8 @@ const superclassManifest = JSON.parse(
 );
 
 const modules = [
-  ts.createSourceFile('my-element.js', defaultCode, ts.ScriptTarget.ES2021, true),
-  ts.createSourceFile('another-class.js', anotherCode, ts.ScriptTarget.ES2021, true),
+  ts.createSourceFile('my-element.js', defaultCode, ts.ScriptTarget.ES2015, true),
+  ts.createSourceFile('another-class.js', anotherCode, ts.ScriptTarget.ES2015, true),
 ];
 
 console.log(

--- a/packages/core/analyzer-import-alias-plugin/src/tsconfig.json
+++ b/packages/core/analyzer-import-alias-plugin/src/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "paths": ["**/*"],
   "compilerOptions": {
-    "target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "es2015" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "moduleResolution": "Node",
     "sourceMap": true /* Create source map files for emitted JavaScript files. */,
     "declaration": true /* Emit .d.ts files */,

--- a/packages/core/analyzer-import-alias-plugin/test/plugin.test.ts
+++ b/packages/core/analyzer-import-alias-plugin/test/plugin.test.ts
@@ -24,8 +24,8 @@ const buildTestCase = async (
   const superclassCode = fs.readFileSync(process.cwd() + anotherFilePath).toString();
 
   const modules = [
-    ts.createSourceFile(baseFilePath, defaultCode, ts.ScriptTarget.ES2021, true),
-    ts.createSourceFile(anotherFilePath, superclassCode, ts.ScriptTarget.ES2021, true),
+    ts.createSourceFile(baseFilePath, defaultCode, ts.ScriptTarget.ES2015, true),
+    ts.createSourceFile(anotherFilePath, superclassCode, ts.ScriptTarget.ES2015, true),
   ];
 
   return (await getAnalyzerCreateHarness())({

--- a/packages/core/cep-fast-plugin/src/tsconfig.json
+++ b/packages/core/cep-fast-plugin/src/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "paths": ["**"],
   "compilerOptions": {
-    "target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "es2015" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "module": "commonjs" /* Specify what module code is generated. */,
     "sourceMap": true /* Create source map files for emitted JavaScript files. */,
     "outDir": "../out" /* Specify an output folder for all emitted files. */,

--- a/packages/core/custom-elements-lsp/README.md
+++ b/packages/core/custom-elements-lsp/README.md
@@ -38,7 +38,7 @@ To use this plugin you have a version of typescript as part of the project, loca
   }
 }
 ```
-> You need to use a target of `ES2021` or later.
+> You need to use a target of `ES2015` or later.
 
 Base options.
 

--- a/packages/core/custom-elements-lsp/src/diagnostics/diagnostics.test.ts
+++ b/packages/core/custom-elements-lsp/src/diagnostics/diagnostics.test.ts
@@ -16,8 +16,11 @@ import {
 } from '../constants/diagnostic-codes';
 import { CustomElementsService } from '../custom-elements/custom-elements.types';
 import { GlobalDataRepository } from '../global-data/global-data.types';
+import { polyFill } from '../utils/polyfill';
 import { CoreDiagnosticsServiceImpl } from './diagnostics';
 import { TagsWithAttrs } from './diagnostics.types';
+
+polyFill();
 
 const getDiagnosticsService = (
   ce: CustomElementsService,
@@ -585,6 +588,7 @@ describe('diagnosticsInvalidElemAttribute', () => {
       const context = html`
         <template><div :wololo="${(_) => ''}" :wolo="${(_) => ''}"></div></template>
       `;
+      // @ts-expect-error
       (context.rawText as any) = context.rawText.replaceAll(':', bindingSymbol);
       const elementList = getElements(context);
       const result = (service as any).diagnosticsInvalidElemAttribute(context, elementList);

--- a/packages/core/custom-elements-lsp/src/diagnostics/diagnostics.ts
+++ b/packages/core/custom-elements-lsp/src/diagnostics/diagnostics.ts
@@ -11,6 +11,7 @@ import {
 import { CustomElementAttribute } from '../custom-elements/custom-elements.types';
 import { escapeRegExp, getPositionOfNthOccuranceEnd, parseAttrNamesFromRawString } from '../utils';
 import { getStore } from '../utils/kvstore';
+import { polyFill } from '../utils/polyfill';
 import { Services } from '../utils/services.types';
 import {
   ATTIBUTE_CLASSIFICATION,
@@ -19,6 +20,8 @@ import {
   InvalidAttrDefinition,
   TagsWithAttrs,
 } from './diagnostics.types';
+
+polyFill();
 
 export class CoreDiagnosticsServiceImpl implements DiagnosticsService {
   constructor(
@@ -139,43 +142,46 @@ export class CoreDiagnosticsServiceImpl implements DiagnosticsService {
 
     const errorAttrs = this.buildInvalidAttrDefinitions(withOccurrences);
 
-    return errorAttrs
-      .filter(({ attr }) => attr.replaceAll('x', '').length > 0)
-      .map(({ tagName, tagNameOccurrence, attr, attrOccurrence, classification }) => {
-        let searchOffset = getPositionOfNthOccuranceEnd({
-          matcher: `<${tagName}`,
-          occurrence: tagNameOccurrence,
-          rawText: context.rawText,
-        });
+    return (
+      errorAttrs
+        // @ts-expect-error
+        .filter(({ attr }) => attr.replaceAll('x', '').length > 0)
+        .map(({ tagName, tagNameOccurrence, attr, attrOccurrence, classification }) => {
+          let searchOffset = getPositionOfNthOccuranceEnd({
+            matcher: `<${tagName}`,
+            occurrence: tagNameOccurrence,
+            rawText: context.rawText,
+          });
 
-        /**
-         * If the attribute is a binding type (used in dialects such as FAST) then
-         * we can avoid matching on substrings just by appending `=` to the match.
-         * Else, we can avoid substring matches using the word boundary matcher `\b`.
-         * If we are using a binding type we need to subtract 1 account for the
-         * `=` character.
-         */
-        const [matcher, offset] = /[@:?]/.test(attr)
-          ? [new RegExp(escapeRegExp(attr) + '='), 1]
-          : [new RegExp(`\\b${escapeRegExp(attr)}\\b`), 0];
+          /**
+           * If the attribute is a binding type (used in dialects such as FAST) then
+           * we can avoid matching on substrings just by appending `=` to the match.
+           * Else, we can avoid substring matches using the word boundary matcher `\b`.
+           * If we are using a binding type we need to subtract 1 account for the
+           * `=` character.
+           */
+          const [matcher, offset] = /[@:?]/.test(attr)
+            ? [new RegExp(escapeRegExp(attr) + '='), 1]
+            : [new RegExp(`\\b${escapeRegExp(attr)}\\b`), 0];
 
-        searchOffset += getPositionOfNthOccuranceEnd({
-          matcher,
-          occurrence: attrOccurrence,
-          rawText: context.rawText.substring(searchOffset),
-        });
+          searchOffset += getPositionOfNthOccuranceEnd({
+            matcher,
+            occurrence: attrOccurrence,
+            rawText: context.rawText.substring(searchOffset),
+          });
 
-        const attrStart = searchOffset - attr.length - offset;
+          const attrStart = searchOffset - attr.length - offset;
 
-        return this.buildAttributeDiagnosticMessage(
-          classification,
-          attr,
-          tagName,
-          sourceFile,
-          attrStart,
-          attr.length,
-        );
-      });
+          return this.buildAttributeDiagnosticMessage(
+            classification,
+            attr,
+            tagName,
+            sourceFile,
+            attrStart,
+            attr.length,
+          );
+        })
+    );
   }
 
   private buildGlobalAttributeArray(): [string, CustomElementAttribute][] {

--- a/packages/core/custom-elements-lsp/src/tsconfig.json
+++ b/packages/core/custom-elements-lsp/src/tsconfig.json
@@ -2,7 +2,7 @@
   "paths": ["**"],
   "exclude": ["**/*.test.ts"],
   "compilerOptions": {
-    "target": "es2021" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "es2015" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "module": "commonjs" /* Specify what module code is generated. */,
     "sourceMap": true /* Create source map files for emitted JavaScript files. */,
     "outDir": "../out" /* Specify an output folder for all emitted files. */,

--- a/packages/core/custom-elements-lsp/src/utils/polyfill.ts
+++ b/packages/core/custom-elements-lsp/src/utils/polyfill.ts
@@ -1,0 +1,15 @@
+export const polyFill = () => {
+  // @ts-expect-error
+  if (!String.prototype.replaceAll) {
+    // @ts-expect-error
+    String.prototype.replaceAll = function (str: string | RegExp, newStr: string) {
+      // If a regex pattern
+      if (Object.prototype.toString.call(str).toLowerCase() === '[object regexp]') {
+        return this.replace(str, newStr);
+      }
+
+      // If a string
+      return this.replace(new RegExp(str, 'g'), newStr);
+    };
+  }
+};


### PR DESCRIPTION
🤔  &nbsp; **What does this PR do?**

Reduces target from ES2021 to ES2015 so projects targetting an older version can use the LSP
- Adds polyfill for functions which are lost from the native code

📑  &nbsp; **How should this be tested?**

Update test steps to match your PR:

```
1. Checkout branch
2. `npm run bootstrap`
3. `npm run test`

Other packages are completely tested via tests from `npm run test`. To test the LSP is working correctly in VSCode:
1. `cd packages/showcase/example`
2. `code .` (or manually open VSCode via the UI to the `example` directory on your filesystem).
3. Open a typescript file such as `root.ts`
4. In the Command Palette choose `TypeScript: select typescript version...` and then choose the workspace version
5. The LSP should be enabled. You will need to make a code change after the LSP is enabled before you see any Intellisense.
```

Everything should work as before

✅  &nbsp; **Checklist**

<!--- Review the list and put an x in the boxes that apply. -->

- [X] I have added tests for my changes.
- [X] I have updated the project documentation.
- [X] I have followed the [contribution guidelines](https://github.com/genesiscommunitysuccess/custom-elements-lsp/blob/master/CONTRIBUTING.md).
