### PR TITLE
fix(custom-elements-lsp): publish test util files which are used by plugins FUI-1595

### DIFF
--- a/packages/core/custom-elements-lsp/.npmignore
+++ b/packages/core/custom-elements-lsp/.npmignore
@@ -1,4 +1,3 @@
 *
 
-!out/main/**
-!out/parser/**
+!out/**


### PR DESCRIPTION
🤔  &nbsp; **What does this PR do?**

- Fixes mistake from #71 which stopped publishing the jest utils, which are used by plugins

📑  &nbsp; **How should this be tested?**

Update test steps to match your PR:

```
1. Checkout branch
2. `npm run bootstrap`
3. `npm run test`
4. `cd packages/core/custom-elements-lsp`
5. `npm pack --dry`
```
Output should contain javascript and other files from `out/jest/*` directory.

✅  &nbsp; **Checklist**

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes. - N/A
- [ ] I have updated the project documentation. - N/A
- [X] I have followed the [contribution guidelines](https://github.com/genesiscommunitysuccess/custom-elements-lsp/blob/master/CONTRIBUTING.md).
