### PR TITLE
fix(custom-elements-lsp): decouple tests exports from jest FUI-1595

### DIFF
--- a/packages/core/custom-elements-lsp/src/jest/utils.ts
+++ b/packages/core/custom-elements-lsp/src/jest/utils.ts
@@ -64,7 +64,7 @@ export const html = (
   const rawText = String.raw({ raw: strings }, ...values.map((v) => '${' + v + '}')) ?? '';
 
   return {
-    typescript: jest.fn() as any,
+    typescript: { _info: 'not implemented' } as any,
     fileName: 'test.ts',
     text: String.raw({ raw: strings }, ...values.map((v) => 'x'.repeat(v.toString().length))) ?? '',
     rawText,


### PR DESCRIPTION
🤔  &nbsp; **What does this PR do?**

- No longer use unnecessary use of `jest.fn` which decouples jest as a dependency to run tests in plugins

📑  &nbsp; **How should this be tested?**

Update test steps to match your PR:

```
1. Checkout branch
2. `npm run bootstrap`
3. `npm run test`

Other packages are completely tested via tests from `npm run test`. To test the LSP is working correctly in VSCode:
1. `cd packages/showcase/example`
2. `code .` (or manually open VSCode via the UI to the `example` directory on your filesystem).
3. Open a typescript file such as `root.ts`
4. In the Command Palette choose `TypeScript: select typescript version...` and then choose the workspace version
5. The LSP should be enabled. You will need to make a code change after the LSP is enabled before you see any Intellisense.
```

All tests should pass as before

✅  &nbsp; **Checklist**

<!--- Review the list and put an x in the boxes that apply. -->

- [X] I have added tests for my changes.
- [X] I have updated the project documentation.
- [X] I have followed the [contribution guidelines](https://github.com/genesiscommunitysuccess/custom-elements-lsp/blob/master/CONTRIBUTING.md).
