### PR TITLE
feat(analyzer-import-alias-plugin): simplify override api FUI-1706

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 out
+.idea

--- a/packages/core/analyzer-import-alias-plugin/README.md
+++ b/packages/core/analyzer-import-alias-plugin/README.md
@@ -49,36 +49,31 @@ export default {
 
 This will effectively treat any imported superclass from `my-library` as without the `Lib` prefix, so in the first example in the readme the local `Button` class will be correctly inheriting from the package `Button` class.
 
-The shape of the function defined as `*` is `(x: string) => string` so you may perform more complicated logic than the above example to mutate the names. If you don't want to change a name you should return the input name.
+The shape of the catch-all function defined as `*` is `(name: string) => string` so you may perform more complicated logic than the above example to mutate the names. If you don't want to change a name you should return the input name.
 
 There is also an option to set specific replacements for names such as the following:
 
 ```typescript
 aliasPlugin({
     'my-library': {
-        '*': (name) => name.replace('Lib',''),
-        override: {
-            LibButton: 'MyButton'
-        }
+        '*': (name) => name.replace('Lib', ''),
+        LibButton: 'MyButton',
+        LibCheckbox: (name) => name.replace('Lib', 'My'),
     }
 })
 ```
 
-When using this above configuration, the `LibButton` superclass inheritance will be treated as `MyButton`. *Important*, the matching `override` definition will take precedence over the `*` function.
+When using this above configuration, the `LibButton` superclass inheritance will be treated as `MyButton`. *Important*, any explicit definition will take precedence over the catch-all `*` function.
 
-For completeness, you may define as many library imports as you wish, and they may have replacement functions, overrides, or both defined.
+For completeness, you may define as many library imports as you wish.
 
 ```typescript
 aliasPlugin({
-    'my-library': {
-        override: {
-            LibButton: 'MyButton'
-        }
+    'my-library': { 
+        LibButton: 'MyButton'
     },
     'another-library': {
-        override: {
-            Banana: 'Apple'
-        }
+        '*': (name) => name.replace('Another', ''),
     }
 })
 ```

--- a/packages/core/analyzer-import-alias-plugin/src/dev.ts
+++ b/packages/core/analyzer-import-alias-plugin/src/dev.ts
@@ -21,7 +21,9 @@ console.log(
       modules,
       plugins: [
         importAliasPlugin({
-          ['my-library']: { override: { ParentElement: 'MyElement' } },
+          ['my-library']: {
+            ParentElement: 'MyElement',
+          },
         }),
       ],
       context: { dev: true, thirdPartyCEMs: [superclassManifest] },

--- a/packages/core/analyzer-import-alias-plugin/test/functions.test.ts
+++ b/packages/core/analyzer-import-alias-plugin/test/functions.test.ts
@@ -180,7 +180,7 @@ describe('getNewSuperclassName', () => {
   describe('when the superclass package is specified, and there is a replacement override', () => {
     it('returns the override name if there is a match', () => {
       const config: ImportAliasPluginOptions = {
-        'my-library': { override: { SuperClass: 'ParentClass' } },
+        'my-library': { SuperClass: 'ParentClass' },
       };
       const res = getNewSuperclassName(
         { ...classDef, superclass: { package: 'my-library', name: 'SuperClass' } },
@@ -194,8 +194,8 @@ describe('getNewSuperclassName', () => {
     it('falls back on the transformer function if there is no matching override', () => {
       const config: ImportAliasPluginOptions = {
         'my-library': {
-          override: { banana: 'apple' },
           '*': (name) => name.replace('Super', 'Base'),
+          banana: 'apple',
         },
       };
       const res = getNewSuperclassName(

--- a/packages/core/analyzer-import-alias-plugin/test/plugin.test.ts
+++ b/packages/core/analyzer-import-alias-plugin/test/plugin.test.ts
@@ -78,7 +78,7 @@ describe('when transforming an import not matching any import', () => {
 
 describe('when transforming an import not matching any override setting', () => {
   it('produces the base-case manifest where the superclass is ignored', async () => {
-    const res = await buildTestCase({ ['my-library']: { override: { noMatch: 'null' } } });
+    const res = await buildTestCase({ ['my-library']: { noMatch: 'null' } });
     expect(res).toEqual(baseCase);
   });
 });
@@ -86,7 +86,7 @@ describe('when transforming an import not matching any override setting', () => 
 describe('when transforming an import using a specific override to allow it to reference the superclass manifest', () => {
   it('the produced manifest has the correct inherited information', async () => {
     const res = await buildTestCase({
-      ['my-library']: { override: { ParentElement: 'MyElement' } },
+      ['my-library']: { ParentElement: 'MyElement' },
     });
     expect(res).toEqual(getCorrectTestAssersion());
   });
@@ -105,8 +105,8 @@ describe('config override takes precedent over the transformer function', () => 
   it('the produced manifest has the correct inherited information', async () => {
     const res = await buildTestCase({
       ['my-library']: {
-        override: { ParentElement: 'MyElement' },
         '*': (name) => name.replace('Parent', 'Base'),
+        ParentElement: 'MyElement',
       },
     });
     expect(res).toEqual(getCorrectTestAssersion());


### PR DESCRIPTION
🤔  &nbsp; **What does this PR do?**

-  Proposes a simplified override API

📑  &nbsp; **How should this be tested?**

Update test steps to match your PR:

```
1. Checkout branch
2. `npm run bootstrap`
3. `npm run test`

Other packages are completely tested via tests from `npm run test`. To test the LSP is working correctly in VSCode:
1. `cd packages/showcase/example`
2. `code .` (or manually open VSCode via the UI to the `example` directory on your filesystem).
3. Open a typescript file such as `root.ts`
4. In the Command Palette choose `TypeScript: select typescript version...` and then choose the workspace version
5. The LSP should be enabled. You will need to make a code change after the LSP is enabled before you see any Intellisense.
```

✅  &nbsp; **Checklist**

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation.
- [ ] I have followed the [contribution guidelines](https://github.com/genesiscommunitysuccess/custom-elements-lsp/blob/master/CONTRIBUTING.md).
