### PR TITLE
build: add postinstall hooks FUI-1707

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@semantic-release/release-notes-generator": "^11.0.4",
         "@typescript-eslint/eslint-plugin": "^5.2.0",
         "@typescript-eslint/parser": "^5.2.0",
+        "chalk": "^4.1.1",
         "commitlint-config-lerna-scopes": "^18.1.0",
         "conventional-changelog-conventionalcommits": "^5.0.0",
         "cross-env": "^7.0.3",
@@ -21309,6 +21310,7 @@
     "packages/core/analyzer-import-alias-plugin": {
       "name": "@genesiscommunitysuccess/analyzer-import-alias-plugin",
       "version": "4.1.3",
+      "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
         "@custom-elements-manifest/analyzer": "0.9.0",
@@ -21339,6 +21341,7 @@
     "packages/core/cep-fast-plugin": {
       "name": "@genesiscommunitysuccess/cep-fast-plugin",
       "version": "4.1.3",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "typescript-template-language-service-decorator": "^2.3.2"
@@ -21356,6 +21359,7 @@
     "packages/core/custom-elements-lsp": {
       "name": "@genesiscommunitysuccess/custom-elements-lsp",
       "version": "4.1.3",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@custom-elements-manifest/analyzer": "^0.8.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@semantic-release/release-notes-generator": "^11.0.4",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "@typescript-eslint/parser": "^5.2.0",
+    "chalk": "^4.1.1",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "cross-env": "^7.0.3",
     "eslint": "8.22.0",

--- a/packages/core/analyzer-import-alias-plugin/README.md
+++ b/packages/core/analyzer-import-alias-plugin/README.md
@@ -24,7 +24,11 @@ This plugin will allow you to fix this issue.
 
 ### Installation
 
-Install this package as a dependency in the same project that you're using the custom elements manifest analyzer.
+Install this package as a dev dependency in the same project that you're using the custom elements manifest analyzer.
+
+```shell
+npm i @genesiscommunitysuccess/analyzer-import-alias-plugin --save-dev
+```
 
 You then need to apply this plugin in the `plugins` settings in your `custom-elements-manifest.config.mjs`, see [here](https://custom-elements-manifest.open-wc.org/analyzer/config/#config-file).
 

--- a/packages/core/analyzer-import-alias-plugin/package.json
+++ b/packages/core/analyzer-import-alias-plugin/package.json
@@ -22,6 +22,7 @@
     "build:watch": "tsc -p ./src/tsconfig.json --watch",
     "clean:dist": "rimraf ./dist",
     "dev": "tsc-watch --project ./src --outDir ./dist --onSuccess \"nodemon ./dist/dev.js\"",
+    "postinstall": "node ./scripts/postinstall.cjs",
     "start:debug": "node --inspect-brk ./dist/dev.js",
     "test:unit": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
     "test:unit:coverage": "npm run test:unit -- --coverage",

--- a/packages/core/analyzer-import-alias-plugin/scripts/postinstall.cjs
+++ b/packages/core/analyzer-import-alias-plugin/scripts/postinstall.cjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+const chalk = require('chalk');
+
+console.log(`
+
+${chalk.green(`Thanks for installing the 'Analyzer Import Alias Plugin'. 🎉`)}
+
+${chalk
+  .black
+  .bgHex('#ff6700')
+  .underline('Please configure to complete integration.')}
+https://www.npmjs.com/package/@genesiscommunitysuccess/analyzer-import-alias-plugin#configuration
+
+`);

--- a/packages/core/cep-fast-plugin/README.md
+++ b/packages/core/cep-fast-plugin/README.md
@@ -15,7 +15,13 @@ This is a [@genesiscommunitysuccess/custom-elements-lsp](https://www.npmjs.com/p
 ## Setup
 
 1. You need to follow the setup guide for the CEP [here](https://www.npmjs.com/package/@genesiscommunitysuccess/custom-elements-lsp).
-2. You need to install this plugin and configure it with the CEP. See instructions [here](https://www.npmjs.com/package/@genesiscommunitysuccess/custom-elements-lsp#fast-syntax).
+2. You need to install this plugin.
+
+```shell
+npm i @genesiscommunitysuccess/cep-fast-plugin --save-dev
+```
+
+3. You need to configure this plugin within the CEP. See instructions [here](https://www.npmjs.com/package/@genesiscommunitysuccess/custom-elements-lsp#fast-syntax).
 
 > If using this plugin and you're using a design system you'll likely want to configure `designSystemPrefix` as specified in the main instructions too.
 

--- a/packages/core/cep-fast-plugin/package.json
+++ b/packages/core/cep-fast-plugin/package.json
@@ -37,6 +37,7 @@
     "build:watch": "tsc -p ./src/tsconfig.json --watch",
     "clean:dist": "rimraf ./out",
     "copy-manifest": "cp ./example/ce.json ./src/jest/ce-test.json",
+    "postinstall": "node ./scripts/postinstall.cjs",
     "test:unit": "jest",
     "test:unit:coverage": "jest --coverage",
     "test:unit:debug": "node --inspect-brk node_modules/jest/bin/jest.js",

--- a/packages/core/cep-fast-plugin/scripts/postinstall.cjs
+++ b/packages/core/cep-fast-plugin/scripts/postinstall.cjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+const chalk = require('chalk');
+
+console.log(`
+
+${chalk.green(`Thanks for installing the 'CEP FAST Plugin'. 🎉`)}
+
+${chalk
+  .black
+  .bgHex('#ff6700')
+  .underline('Please configure to complete integration.')}
+https://www.npmjs.com/package/@genesiscommunitysuccess/cep-fast-plugin#setup
+
+`);

--- a/packages/core/custom-elements-lsp/README.md
+++ b/packages/core/custom-elements-lsp/README.md
@@ -23,7 +23,12 @@ There is an additional [companion plugin](https://www.npmjs.com/package/@genesis
 These instructions are for setting up the LSP in your application. If you are wanting to set up the LSP test it or contribute to it then go to [this section](#plugin-development).
 To use this plugin you have a version of typescript as part of the project, located inside of the `node_modules`.
 
-1. Ensure the package is installed in your `package.json` and you've run `npm install`.
+1. Install this package as a dev dependency in the target project.
+
+```shell
+npm i @genesiscommunitysuccess/custom-elements-lsp --save-dev
+```
+
 2. Configure the plugin in the `tsconfig.json`. The following is an example shape, see below for full explanations.
 
 ```json

--- a/packages/core/custom-elements-lsp/package.json
+++ b/packages/core/custom-elements-lsp/package.json
@@ -46,6 +46,7 @@
     "build:watch": "npm run build:lsp -- --watch",
     "clean:dist": "rimraf ./out",
     "copy-manifest": "cp ./example/ce.json ./src/jest/ce-test.json",
+    "postinstall": "node ./scripts/postinstall.cjs",
     "test:unit": "jest",
     "test:unit:coverage": "jest --coverage",
     "test:unit:debug": "node --inspect-brk node_modules/jest/bin/jest.js",

--- a/packages/core/custom-elements-lsp/scripts/postinstall.cjs
+++ b/packages/core/custom-elements-lsp/scripts/postinstall.cjs
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+const chalk = require('chalk');
+
+console.log(`
+
+${chalk.green(`Thanks for installing the 'Custom Elements LSP Plugin'. 🎉`)}
+
+${chalk
+  .black
+  .bgHex('#ff6700')
+  .underline('Please configure your tsconfig.json and IDE to complete integration.')}
+https://www.npmjs.com/package/@genesiscommunitysuccess/custom-elements-lsp#plugin-setup-and-usage
+
+`);


### PR DESCRIPTION
📷  &nbsp; **Samples**


![Screenshot 2023-12-13 at 13 12 55](https://github.com/genesiscommunitysuccess/custom-elements-lsp/assets/190318/57b7bc70-4af9-44e0-b358-3a8c1951f61e)

![Screenshot 2023-12-13 at 13 06 55](https://github.com/genesiscommunitysuccess/custom-elements-lsp/assets/190318/d19fad02-cee1-4567-8312-05df5de6daf2)

![Screenshot 2023-12-13 at 13 20 20](https://github.com/genesiscommunitysuccess/custom-elements-lsp/assets/190318/a9fa649c-dd05-4761-8f74-5ce22808a5d3)


📓  &nbsp; **Related Issue**
If this PR is related to an issue then link it here, or delete this section.

🤔  &nbsp; **What does this PR do?**

- Adds postinstall hooks to inform users of additional steps. We may be able to build on these to apply some automatic setup.

📑  &nbsp; **How should this be tested?**

You can manually run: `npm run postinstall` in each to check what the users should see after they install these in the wild.

✅  &nbsp; **Checklist**

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [ ] I have updated the project documentation.
- [ ] I have followed the [contribution guidelines](https://github.com/genesiscommunitysuccess/custom-elements-lsp/blob/master/CONTRIBUTING.md).
