### PR TITLE
fix: exclude scripts dirs from .npmignore FUI-1722

### DIFF
--- a/packages/core/analyzer-import-alias-plugin/.npmignore
+++ b/packages/core/analyzer-import-alias-plugin/.npmignore
@@ -2,3 +2,4 @@
 
 !dist/index.js
 !dist/index.d.ts
+!scripts/**

--- a/packages/core/cep-fast-plugin/.npmignore
+++ b/packages/core/cep-fast-plugin/.npmignore
@@ -3,3 +3,4 @@
 !out/**/*.js
 out/**/*.test.js
 !docs/**
+!scripts/**

--- a/packages/core/custom-elements-lsp/.npmignore
+++ b/packages/core/custom-elements-lsp/.npmignore
@@ -2,3 +2,4 @@
 
 !out/**
 !docs/**
+!scripts/**


### PR DESCRIPTION
📷  &nbsp; **Samples**

NA

📓  &nbsp; **Related Issue**
If this PR is related to an issue then link it here, or delete this section.

🤔  &nbsp; **What does this PR do?**

- Didn't realise we had a blanket ignore rule in place. Exclude the scripts dirs.

📑  &nbsp; **How should this be tested?**

Update test steps to match your PR:

```
1. Checkout branch
2. `npm run bootstrap`
3. `npm run test`

Other packages are completely tested via tests from `npm run test`. To test the LSP is working correctly in VSCode:
1. `cd packages/showcase/example`
2. `code .` (or manually open VSCode via the UI to the `example` directory on your filesystem).
3. Open a typescript file such as `root.ts`
4. In the Command Palette choose `TypeScript: select typescript version...` and then choose the workspace version
5. The LSP should be enabled. You will need to make a code change after the LSP is enabled before you see any Intellisense.
```

✅  &nbsp; **Checklist**

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have added tests for my changes.
- [ ] I have updated the project documentation.
- [ ] I have followed the [contribution guidelines](https://github.com/genesiscommunitysuccess/custom-elements-lsp/blob/master/CONTRIBUTING.md).
