### PR TITLE
fix: relocate chalk to packages FUI-1722

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@semantic-release/release-notes-generator": "^11.0.4",
         "@typescript-eslint/eslint-plugin": "^5.2.0",
         "@typescript-eslint/parser": "^5.2.0",
-        "chalk": "^4.1.1",
         "commitlint-config-lerna-scopes": "^18.1.0",
         "conventional-changelog-conventionalcommits": "^5.0.0",
         "cross-env": "^7.0.3",
@@ -8208,7 +8207,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -9006,7 +9004,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -9307,7 +9304,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -9318,8 +9314,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -12352,7 +12347,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -19940,7 +19934,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -21312,6 +21305,9 @@
       "version": "5.0.1",
       "hasInstallScript": true,
       "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.1"
+      },
       "devDependencies": {
         "@custom-elements-manifest/analyzer": "0.9.0",
         "@types/jest": "^29.5.1",
@@ -21344,6 +21340,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "chalk": "^4.1.1",
         "typescript-template-language-service-decorator": "^2.3.2"
       },
       "devDependencies": {
@@ -21363,6 +21360,7 @@
       "license": "MIT",
       "dependencies": {
         "@custom-elements-manifest/analyzer": "^0.8.0",
+        "chalk": "^4.1.1",
         "chokidar": "^3.5.3",
         "debounce": "^1.2.1",
         "get-tsconfig": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "@semantic-release/release-notes-generator": "^11.0.4",
     "@typescript-eslint/eslint-plugin": "^5.2.0",
     "@typescript-eslint/parser": "^5.2.0",
-    "chalk": "^4.1.1",
     "conventional-changelog-conventionalcommits": "^5.0.0",
     "cross-env": "^7.0.3",
     "eslint": "8.22.0",

--- a/packages/core/analyzer-import-alias-plugin/package.json
+++ b/packages/core/analyzer-import-alias-plugin/package.json
@@ -42,6 +42,9 @@
   ],
   "author": "",
   "license": "MIT",
+  "dependencies": {
+    "chalk": "^4.1.1"
+  },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "0.9.0",
     "@types/jest": "^29.5.1",

--- a/packages/core/cep-fast-plugin/package.json
+++ b/packages/core/cep-fast-plugin/package.json
@@ -45,6 +45,7 @@
     "test:unit:watch": "jest --watchAll"
   },
   "dependencies": {
+    "chalk": "^4.1.1",
     "typescript-template-language-service-decorator": "^2.3.2"
   },
   "devDependencies": {

--- a/packages/core/custom-elements-lsp/package.json
+++ b/packages/core/custom-elements-lsp/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "@custom-elements-manifest/analyzer": "^0.8.0",
+    "chalk": "^4.1.1",
     "chokidar": "^3.5.3",
     "debounce": "^1.2.1",
     "get-tsconfig": "^4.7.0",


### PR DESCRIPTION
📷  &nbsp; **Samples**

NA

📓  &nbsp; **Related Issue**
If this PR is related to an issue then link it here, or delete this section.

🤔  &nbsp; **What does this PR do?**

- Relocate the chalk dependency to each package.

📑  &nbsp; **How should this be tested?**

Update test steps to match your PR:

```
1. Checkout branch
2. `npm run bootstrap`
3. `npm run test`

Other packages are completely tested via tests from `npm run test`. To test the LSP is working correctly in VSCode:
1. `cd packages/showcase/example`
2. `code .` (or manually open VSCode via the UI to the `example` directory on your filesystem).
3. Open a typescript file such as `root.ts`
4. In the Command Palette choose `TypeScript: select typescript version...` and then choose the workspace version
5. The LSP should be enabled. You will need to make a code change after the LSP is enabled before you see any Intellisense.
```

✅  &nbsp; **Checklist**

<!--- Review the list and put an x in the boxes that apply. -->

- [] I have added tests for my changes.
- [ ] I have updated the project documentation.
- [ ] I have followed the [contribution guidelines](https://github.com/genesiscommunitysuccess/custom-elements-lsp/blob/master/CONTRIBUTING.md).
