### PR TITLE
fix: add full filepath to main file in package.json FUI-1827

### DIFF
--- a/packages/core/analyzer-import-alias-plugin/package.json
+++ b/packages/core/analyzer-import-alias-plugin/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.2",
   "description": "Plugin for custom element manifest parser to handle import aliases",
   "type": "module",
-  "main": "./dist",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "repository": {
     "type": "git",

--- a/packages/core/cep-fast-plugin/package.json
+++ b/packages/core/cep-fast-plugin/package.json
@@ -2,7 +2,7 @@
   "name": "@genesiscommunitysuccess/cep-fast-plugin",
   "version": "5.0.2",
   "license": "MIT",
-  "main": "./out",
+  "main": "./out/index.js",
   "description": "Plugin for @genesiscommunitysuccess/custom-elements-lsp which enables https://www.fast.design/ enhancements",
   "keywords": [
     "analyzer",

--- a/packages/core/custom-elements-lsp/package.json
+++ b/packages/core/custom-elements-lsp/package.json
@@ -2,7 +2,7 @@
   "name": "@genesiscommunitysuccess/custom-elements-lsp",
   "version": "5.0.2",
   "license": "MIT",
-  "main": "./out/main/",
+  "main": "./out/main/index.js",
   "exports": {
     ".": "./out/main/index.js",
     "./out/main/plugins/export-interface": "./out/main/plugins/export-interface.js"


### PR DESCRIPTION
🤔  &nbsp; **What does this PR do?**

- fixes issue `has a "main" field set to "./dist", excluding the full filename and extension to the resolved file at "dist/index.js"`

📑  &nbsp; **How should this be tested?**

Update test steps to match your PR:

```
1. Checkout branch
2. `npm run bootstrap`
3. `npm run test`

Other packages are completely tested via tests from `npm run test`. To test the LSP is working correctly in VSCode:
1. `cd packages/showcase/example`
2. `code .` (or manually open VSCode via the UI to the `example` directory on your filesystem).
3. Open a typescript file such as `root.ts`
4. In the Command Palette choose `TypeScript: select typescript version...` and then choose the workspace version
5. The LSP should be enabled. You will need to make a code change after the LSP is enabled before you see any Intellisense.
```

✅  &nbsp; **Checklist**

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have updated the project documentation.
- [X] I have followed the [contribution guidelines](https://github.com/genesiscommunitysuccess/custom-elements-lsp/blob/master/CONTRIBUTING.md).
